### PR TITLE
Add Spanish version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/anacoimbrag/android-developer-roadmap.svg?style=flat-square)
 
 **Para a versão em português, [clique aqui](./README_PT_BR.md)**
+**Para la versión en español, [clic auquí](./README_ES.md)**
 
 Based on the [Developer Roadmap](https://github.com/kamranahmedse/developer-roadmap) that helps web developers with a path of what to learn on this extensive area, we developed the Android Developer Roadmap with the same goal.
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -1,0 +1,53 @@
+# Android Developer Roadmap 2020
+
+![GitHub contributors](https://img.shields.io/github/contributors/anacoimbrag/android-developer-roadmap.svg?style=flat-square)
+
+**Para a versão em português, [clique aqui](./README_PT_BR.md)**
+**For the english version, [click here](./README.md)**
+
+
+Basado en el [Developer Roadmap](https://github.com/kamranahmedse/developer-roadmap) que ayuda a los web developers con la ruta a seguir para aprender en su extensa área, hemos implementado el Android Developer Roadmap con la misma finalidad.
+
+Esperamos que con esta hoja de ruta, los nuevos desarrolladores encuentren de una forma simple cómo empezar a implementar aplicaciones Android.
+
+## Cómo leerla
+
+Estos contenidos, son una ruta sugerida para ayudarte en tus estudios de Android. Para usarlos, ten en cuenta que el diagrama se basa en macro boxes (nodo padre), que estan en la mitad del diagrama (siguiendo la línea continua), y desde allí tenemos micro boxes (nodos hijos), con contenidos más puntuales acerca del tópico del nodo padre.
+
+De esta manera, te sugerimos para su mejor lectura y comprensión, comenzar leyendo de arriba a abajo. Así es como creemos que la hoja de ruta debe fluir, basados en lo que se necesita y su grado de dificultad.
+
+Es importante resaltar que no debes saber absolutamente todo lo que aparece en el diagrama para ser un muy buen desarrollador de Android. Be paso a paso según tus necesidades (tus estudios, proyectos personales, etc) y todo irá bien.
+
+Recuerda que esto es un contenido colaborativo, por tanto, si de pronto falta algo, piensa en cómo mejorarlo y hacerlo disponible para la comunidad.
+
+## Android Roadmap (Hoja de Ruta en Desarrollo Android)
+
+![Android Roadmap](./images/android_roadmap.png)
+
+## Agradecimientos
+
+Queremos agradecer a la comunidad Android de todo el mundo que nos ha ayudado con grandes ideas, especialmente a [Android Dev BR](https://github.com/androiddevbr). 
+Sin ustedes este proyecto no estaría tan completo a como está actualmente.
+
+## Contribuye
+
+Si consideras que algún contenido sobra o que falta algún otro o que deba ser diferente, abre por favor un pull request con tus ideas.
+
+[Aquí](./docs/contributing.md) puedes encontrar cómo contribuir con el roadmap.
+
+## Autores
+
+[1.1]: http://i.imgur.com/wWzX9uB.png (follow me on twitter)
+[2.1]: http://i.imgur.com/9I6NRUm.png (follow me on github)
+
+[1]: https://twitter.com/anacoimbrag
+[2]: https://github.com/anacoimbrag
+[3]: https://twitter.com/DrCabrales
+[4]: https://github.com/drcabral/
+
+- Ana Coimbra [![alt text][1.1]][1][![alt text][2.1]][2]
+- Diogo Cabral [![alt text][1.1]][3][![alt text][2.1]][4]
+
+## Licencia
+
+[![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg)](https://creativecommons.org/licenses/by/4.0/)

--- a/README_PT_BR.md
+++ b/README_PT_BR.md
@@ -3,6 +3,7 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/anacoimbrag/android-developer-roadmap.svg?style=flat-square)
 
 **For the english version, [click here](./README.md)**
+**Para la versión en español, [clic auquí](./README_ES.md)**
 
 Baseado no [Developer Roadmap](https://github.com/kamranahmedse/developer-roadmap), que ajuda pessoas desenvolvedoras web com um direcionamento sobre o que aprender nessa área extensa, nós desenvolvemos o Android Developer Roadmap com o mesmo objetivo.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,7 @@
 # Contributing to Android Developer Roadmap 2020
 
 **Para a versão em portuguese, [clique aqui](./contributing_pt_br.md)**
+**Para la versión en español, [clic aquí](./contributing_es.md)**
 
 ## Generating discussions
 

--- a/docs/contributing_es.md
+++ b/docs/contributing_es.md
@@ -1,0 +1,47 @@
+# Contribuye al Roadmap para Android Developer 2020
+
+**Para a versão em portuguese, [clique aqui](./contributing_pt_br.md)**
+**For the english version, [click here](./contributing.md)**
+
+## Generando discusiones
+
+Si tienes alguna sugerencia acerca de algo que deba estar en el roadmap y quieres validarlo, te recomendamos que crees un `issue` en nuestro repositorio. De esta manera, podemos lograr discusiones interesantes que seguramente ayudarán a muchas personas acerca de la adopción de este contenidos dentro de sus desarrollos.
+
+## Creando Mejoras
+
+Si tienes alguna idea de mejora directamente sobre lo representado en el roadmap, te recomendamos crear un `pull request` con básicamente dos archivos: la **imagen del roadmap** y el **archivo .fig**, ambos actualizados. Trate de ser bien descriptivo en el PR, así nosotros podemos analizar y discutir mejor lo que estás proponiendo.
+
+### Usando Figma
+
+Nuestro proyecto está implementado usando [Figma](https://www.figma.com/). Figma es una herramienta libre usualmente utilizada para crear prototipos, así, resulta ser la mejor opción para el roadmap, dado que nuestra idea es que cada quien pueda usar la herramienta para mejorar el contenido.
+
+1. Importar el roadmap
+
+    Después de clonar el repositorio, encontrarás dentro de la carpeta `project` el archivo `Android Developer Roadmap 2020.fig`. Con éste, puedes importar el proyecto dentro de tu perfil de Figma para editarlo.
+
+    ![Cómo importar un archivo .fig en Figma](./importing_project.png)
+
+2. Acceso y edición del contenido
+
+    Después de subir el archivo, puedes acceder el contenido haciendo doble-clic en `Android Developer Roadmap 2020`. Con clic derecho en él, debes desagrupar el contenido para así acceder a cada componente y editarlo.
+
+    ![Desagrupar el contenido](./ungroup_content.png)
+
+    Ahora, puedes hacer clic en cada componente padre, cada nodo hijo y demás para cambiar lo que requieras. Ten en cuenta que si cambias algo del componente principal (el nodo con el contenido `Programming Language`) todos los cambios se aplicarán a los demas componentes.
+
+3. Exportar los cambios
+
+    Después de que actualices los contenidos, debes `exportar el archivo .fig`. PUedes hacerlo haciendo clic en `menú de la izquierda > file > Save as .fig...`.
+
+    ![Exportar el archivo .fig](./exporting_fig_file.png)
+
+    Como parte del pull request, necesitas enviar también la imagen actualizada. Para ello, debes `agrupar el contenido` similar a como cuando lo desagrupaste. Después, la opción `export` se desplegará en el menú de la parte inferior derecha. Haz clic en `+`, pon la info en Sufix, manteniendo el formato `PNG` y haz clic en `Export Group x`. La imagen será descargada.
+
+    ![Exportando la imagen](./exporting_image.png)
+
+    El patrón que usamos para nombrar el archivo .fig es `Android Developer Roadmap 2020.fig`, y el usado para la imagen es `android_roadmap.png`. Debes usar los mismos.
+
+## Déjanos tu feedback!
+
+Is this file helpful? Did you have any difficulties to do your updates or suggestions? Please let us know! With you help we can not only improve the roadmap but this step by step about how to improve it with us.
+Ha sido de ayuda esta guía? Tuviste alguna dificultad haciendo alguna actualización? Tienes alguna sugerencia adicional? Déjanos saberlo por favor! Con tu ayuda no solamente mejoraremos el roadmap sino también este paso a paso.

--- a/docs/contributing_pt_br.md
+++ b/docs/contributing_pt_br.md
@@ -1,6 +1,7 @@
 # Contributing to Android Developer Roadmap 2020
 
 **For the english version, [click here](./contributing.md)**
+**Para la versión en español, [clic aquí](./contributing_es.md)**
 
 ## Gerando discussões
 


### PR DESCRIPTION
A Spanish version of README and docs/contributing files has been added. I consider it's important to have this versions due to the growing number of Latin American developers that are developing Android on a daily basis